### PR TITLE
Add instructions on changing SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ AWS SDK framework for OS X. Created by modifying the official AWS SDK for iOS. T
 http://aws.amazon.com/sdkforios
 
 To build the AWS SDK for OSX, open the Xcode project src/AWSiOSSDK.xcodeproj. Build the framework target. The new framework directory will be placed in the top-level directory of the repo.
+
+This is configured for 10.7. If you want to build against 10.8 or later, you'll need to change both the SDK targets in Build Settings and line 38 of src/Scripts/Framework.sh.


### PR DESCRIPTION
I'm building for 10.8, and it took a bit to figure out that I also needed to change Scripts/Framework.sh. This adds instructions for anyone going forward who might want to build against Mavericks, etc.

Thanks for figuring out how to build this for OS X!
